### PR TITLE
fix: External link detection

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,4 +1,4 @@
-{{ $isExternal := and (strings.HasPrefix .Destination "http") (not (strings.Contains .Destination site.BaseURL)) }}
+{{ $isExternal := strings.HasPrefix .Destination "http" }}
 <a
   href="{{ .Destination | safeURL }}"
   {{ with .Title -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
     {{ $style := resources.Get "dist/style.css" | fingerprint }}
     <link
       rel="stylesheet"
-      href="{{ $style.Permalink }}"
+      href="{{ $style.RelPermalink }}"
       integrity="{{ $style.Data.Integrity }}"
     />
   </head>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,7 +21,7 @@
           alt="Chathan Driehuys headshot"
           class="mx-auto rounded-full border-4 border-blue-500 md:mx-0"
           height="{{ $headshot.Height }}"
-          src="{{ $headshot.Permalink }}"
+          src="{{ $headshot.RelPermalink }}"
           width="{{ $headshot.Width }}"
         />
       </section>

--- a/layouts/partials/paginated-post-list.html
+++ b/layouts/partials/paginated-post-list.html
@@ -2,7 +2,7 @@
   {{ range .Pages }}
     <li class="mb-4">
       <h3 class="mb-2 text-lg">
-        <a class="text-blue-500 underline" href="{{ .Permalink }}"
+        <a class="text-blue-500 underline" href="{{ .RelPermalink }}"
           >{{ .Title }}</a
         >
         &mdash;

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -2,6 +2,6 @@
 {{ $caption := .Get "caption" }}
 {{ $alt := default $caption (.Get "alt") }}
 <figure>
-  <img alt="{{ $alt }}" src="{{ $img.Permalink }}" />
+  <img alt="{{ $alt }}" src="{{ $img.RelPermalink }}" />
   <figcaption>{{ $caption }}</figcaption>
 </figure>


### PR DESCRIPTION
Uncomplicate external link detection by using relative links within the
site. This means that anything starting with an `http` prefix can be
assumed to be an external link.

Fixes #24
