### PR TITLE
Set correct domain in production

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,3 +1,4 @@
+baseURL = "https://www.chathandriehuys.com"
 languageCode = 'en-us'
 title = 'Chathan Driehuys - Software Developer'
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,9 @@
 [build]
   publish = "public"
-  command = "npm run build -- -- --baseURL $DEPLOY_PRIME_URL"
+  command = "npm run build"
 
-[build.environment]
-  HUGO_VERSION = "0.111.3"
+  [build.environment]
+    HUGO_VERSION = "0.111.3"
+
+[context.deploy-preview]
+  command = "npm run build -- -- --baseURL $DEPLOY_PRIME_URL"


### PR DESCRIPTION
Since `$DEPLOY_PRIME_URL` references a branch name, it's not the proper choice for our production build. Instead, we default to the production domain.

- In production, it's unchanged and correct.
- For deploy previews, we override with `$DEPLOY_PRIME_URL` which is correct since all we care about is a unique URL for the deploy preview.
- For development, we run through `hugo server` which already overrides the base URL to be `localhost:1313`.
